### PR TITLE
README.md: use `fontmake -o variable`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,20 +19,13 @@ In the `example` directory, you can find a sample DesignSpace file and interpola
   - create a new text file called `yourfont.designspace`
   - Populate the file using the following examples as a guide. Most importantly, make sure the paths to the UFOs are correct. https://github.com/scribbletone/i-can-variable-font/blob/master/example/varibox.designspace and https://github.com/LettError/MutatorMath/blob/master/Docs/designSpaceFileFormat.md
   - Add at least one instance
-4. Generate interpolatable TTFs
+4. Generate the final variable font
   - In Terminal, [navigate](https://github.com/scribbletone/i-can-variable-font#terminal-tips) to the `fontmake` directory.
     - If you’ve closed the Terminal window since installing, you’ll also need to run `source env/bin/activate`.
-  - run `fontmake -o ttf-interpolatable -m path-to-your-designspace-file`. 
+  - run `fontmake -o variable -m path-to-your-designspace-file`. 
     - Make sure to substitute your path to the DesignSpace file.
-  - If all goes well, you should now have TTFs in the `fontmake/master_ttf_interpolatable` directory.
-5. Generate the final variable font
-  - Copy the generated TTFs from the previous step, and place them in the same directory as your source UFOs.
-  - Make sure the TTFs have the same file name as your UFOs(without the file extension). If not, you’ll get an error. 
-  - From the `fontmake` directory run `fonttools varLib path-to-your-designspace-file`.  
-    - Again, make sure to substitute your path to the DesignSpace file.
-    - This command changed in version 3.2.0 of fonttools. If you’re using an older installation, you may need to run `python env/lib/python2.7/site-packages/fontTools/varLib/__init__.py path-to-your-designspace-file`
   - Cross your fingers :)
-  - If everything goes well, you should end up with a new TTF file next to the DesignSpace with `-VF`(or `-GX` on older versions) in the name.
+  - If everything goes well, you should end up with a new TTF file with `-VF` in the name, located in a `variable_ttf` subfolder.
 
 ## Weird Things
 - Your sources seem to need a `GPOS` or kerning table. In the example file, I got around that by just creating a single kerning pair with a value of 0.


### PR DESCRIPTION
You don't need to create the `ttf-interpolatable` first and then call `fonttools varLib` on them; you can simply use `fontmake -o variable` to produce the final variable fonts directly, without the extra final step. Fontmake uses fonttools behind the scenes.

/cc @lorp